### PR TITLE
feat: OIDC id-token after device association, Keycloak handoff, and POC wiring

### DIFF
--- a/IDDigitalSDK/build.gradle.kts
+++ b/IDDigitalSDK/build.gradle.kts
@@ -13,7 +13,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "uy.com.abitab"
                 artifactId = "iddigitalsdk"
-                version = "0.0.1"
+                version = "1.0.0"
             }
         }
     }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDK.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDK.kt
@@ -174,7 +174,7 @@ object CallbackHandler {
         onErrorHandler?.invoke(error)
     }
 
-    fun onCompleted(challengeId: String) {
-        onCompletedHandler?.invoke(challengeId)
+    fun onCompleted(value: String) {
+        onCompletedHandler?.invoke(value)
     }
 }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDK.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDK.kt
@@ -210,6 +210,9 @@ class IDDigitalSDK private constructor() {
 //        }
 //    }
 
+    /**
+     * @param sdkToken OIDC ID token (JWT) from `DeviceAssociation.idToken`, sent to Keycloak as `sdk_token`.
+     */
     suspend fun sendToKeycloak(
         tabId: String,
         sessionCode: String,

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDK.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDK.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import getDeviceAssociation
 import kotlinx.coroutines.CoroutineScope
+
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -16,10 +17,15 @@ import removeDeviceAssociation
 import uy.com.abitab.iddigitalsdk.data.PinDataStoreManager
 import uy.com.abitab.iddigitalsdk.di.sdkModule
 import uy.com.abitab.iddigitalsdk.domain.models.ChallengeType
+import uy.com.abitab.iddigitalsdk.domain.models.DeviceAssociation
 import uy.com.abitab.iddigitalsdk.domain.models.Document
 import uy.com.abitab.iddigitalsdk.domain.models.IDDigitalSDKEnvironment
+import uy.com.abitab.iddigitalsdk.domain.models.Record
 import uy.com.abitab.iddigitalsdk.domain.usecases.CheckCanAssociateUseCase
+import uy.com.abitab.iddigitalsdk.domain.usecases.CreateValidationSessionUseCase
+// import uy.com.abitab.iddigitalsdk.domain.usecases.ExecuteChallengeUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.RemoveAssociationUseCase
+// import uy.com.abitab.iddigitalsdk.domain.usecases.ValidateChallengeUseCase
 import uy.com.abitab.iddigitalsdk.presentation.device_association.ui.DeviceAssociationActivity
 import uy.com.abitab.iddigitalsdk.presentation.validation_session.ui.ValidationSessionActivity
 import uy.com.abitab.iddigitalsdk.utils.AmplifyInitializer
@@ -32,6 +38,9 @@ class IDDigitalSDK private constructor() {
     private var checkCanAssociateUseCase: CheckCanAssociateUseCase
     private var removeAssociationUseCase: RemoveAssociationUseCase
     private var pinDataStoreManager: PinDataStoreManager
+    private var createValidationSessionUseCase: CreateValidationSessionUseCase
+//    private var executeChallengeUseCase: ExecuteChallengeUseCase
+//    private var validateChallengeUseCase: ValidateChallengeUseCase
 
     private val koin by lazy { GlobalContext.get() }
 
@@ -39,6 +48,9 @@ class IDDigitalSDK private constructor() {
         checkCanAssociateUseCase = koin.get()
         removeAssociationUseCase = koin.get()
         pinDataStoreManager = koin.get()
+        createValidationSessionUseCase = koin.get()
+//        executeChallengeUseCase = koin.get()
+//        validateChallengeUseCase = koin.get()
     }
 
 
@@ -76,6 +88,7 @@ class IDDigitalSDK private constructor() {
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
                         AmplifyInitializer.initialize(context)
+                        onCompleted("IDDigitalSDK initialized successfully")
                     } catch (e: Throwable) {
                         onError(e.toIDDigitalError())
                     }
@@ -83,7 +96,6 @@ class IDDigitalSDK private constructor() {
 
                 registerPermissionLauncher(context)
 
-                onCompleted("IDDigitalSDK initialized successfully")
             }
             return instance!!
         }
@@ -131,6 +143,19 @@ class IDDigitalSDK private constructor() {
         return retrievedAssociation != null
     }
 
+    suspend fun getDeviceAssociation(
+        onError: (IDDigitalError) -> Unit,
+        onSuccess: (DeviceAssociation?) -> Unit
+    ) {
+        try {
+            val context = applicationContext
+            val association = context.getDeviceAssociation().firstOrNull()
+            onSuccess(association)
+        } catch (e: Throwable) {
+            onError(e.toIDDigitalError())
+        }
+    }
+
     suspend fun removeAssociation() {
         val context = applicationContext
         try {
@@ -155,6 +180,52 @@ class IDDigitalSDK private constructor() {
 
         val intent = ValidationSessionActivity.createIntent(context, type)
         context.startActivity(intent)
+    }
+
+//    suspend fun executeChallenge(
+//        challengeId: String,
+//        data: Record,
+//        onError: (IDDigitalError) -> Unit,
+//        onCompleted: () -> Unit
+//    ) {
+//        try {
+//            executeChallengeUseCase(challengeId, data)
+//            onCompleted()
+//        } catch (e: Throwable) {
+//            onError(e.toIDDigitalError())
+//        }
+//    }
+
+//    suspend fun validateChallenge(
+//        challengeId: String,
+//        data: Record,
+//        onError: (IDDigitalError) -> Unit,
+//        onResult: (Boolean) -> Unit
+//    ) {
+//        try {
+//            val isValid = validateChallengeUseCase(challengeId, data)
+//            onResult(isValid)
+//        } catch (e: Throwable) {
+//            onError(e.toIDDigitalError())
+//        }
+//    }
+
+    suspend fun sendToKeycloak(
+        tabId: String,
+        sessionCode: String,
+        clientId: String,
+        realm: String,
+        sdkToken: String,
+        onError: (IDDigitalError) -> Unit,
+        onSuccess: (String) -> Unit
+    ) {
+        try {
+            val keycloakService: uy.com.abitab.iddigitalsdk.data.network.KeycloakService = koin.get()
+            val response = keycloakService.sendAuthenticationData(tabId, sessionCode, clientId, realm, sdkToken)
+            onSuccess(response)
+        } catch (e: Throwable) {
+            onError(e.toIDDigitalError())
+        }
     }
 }
 

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDKBridge.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/IDDigitalSDKBridge.kt
@@ -1,0 +1,235 @@
+package uy.com.abitab.iddigitalsdk
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import uy.com.abitab.iddigitalsdk.domain.models.ChallengeType
+import uy.com.abitab.iddigitalsdk.domain.models.DeviceAssociation
+import uy.com.abitab.iddigitalsdk.domain.models.Document
+import uy.com.abitab.iddigitalsdk.domain.models.IDDigitalSDKEnvironment
+import uy.com.abitab.iddigitalsdk.domain.models.Record
+import uy.com.abitab.iddigitalsdk.domain.models.ValidationSession
+import uy.com.abitab.iddigitalsdk.utils.IDDigitalError
+import uy.com.abitab.iddigitalsdk.utils.toIDDigitalError
+
+// ---------------------------------------------------------
+// Wrapper Kotlin -> Java
+// ---------------------------------------------------------
+object IDDigitalSDKJavaWrapper {
+
+    private var sdk: IDDigitalSDK? = null
+
+    // ---------------------------------------------------------
+    // Interfaces Java-friendly
+    // ---------------------------------------------------------
+    @FunctionalInterface
+    interface OnErrorListener {
+        fun onError(error: IDDigitalError)
+    }
+
+    @FunctionalInterface
+    interface OnCompletedListener {
+        fun onCompleted(value: String)
+    }
+
+    @FunctionalInterface
+    interface OnBooleanResultListener {
+        fun onResult(value: Boolean)
+    }
+
+    @FunctionalInterface
+    interface OnValidationSessionListener {
+        fun onSuccess(session: ValidationSession)
+    }
+
+    @FunctionalInterface
+    interface OnDeviceAssociationListener {
+        fun onSuccess(association: DeviceAssociation?)
+    }
+
+    @JvmStatic
+    fun initialize(
+        context: Context,
+        apiKey: String,
+        environment: IDDigitalSDKEnvironment,
+        onError: OnErrorListener?,
+        onCompleted: OnCompletedListener?
+    ) {
+        try {
+            sdk = IDDigitalSDK.initialize(
+                context,
+                apiKey,
+                environment,
+                { error -> onError?.onError(error) },
+                { result -> onCompleted?.onCompleted(result) }
+            )
+        } catch (e: Throwable) {
+            onError?.onError(e.toIDDigitalError())
+        }
+    }
+
+    @JvmStatic
+    fun associate(
+        context: Context,
+        document: Document,
+        onError: OnErrorListener?,
+        onCompleted: OnCompletedListener?
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                sdk?.associate(
+                    context,
+                    document,
+                    { error -> onError?.onError(error) },
+                    { result -> onCompleted?.onCompleted(result) }
+                )
+            } catch (e: Throwable) {
+                onError?.onError(e.toIDDigitalError())
+            }
+        }
+    }
+
+    @JvmStatic
+    fun canAssociate(
+        document: Document,
+        onError: OnErrorListener?,
+        listener: OnBooleanResultListener
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val result = try {
+                sdk?.canAssociate(document, { error -> onError?.onError(error) }) ?: false
+            } catch (e: Throwable) {
+                onError?.onError(e.toIDDigitalError())
+                false
+            }
+            listener.onResult(result)
+        }
+    }
+
+    @JvmStatic
+    fun isAssociated(listener: OnBooleanResultListener) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val result = sdk?.isAssociated() ?: false
+            listener.onResult(result)
+        }
+    }
+
+    @JvmStatic
+    fun removeAssociation() {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                sdk?.removeAssociation()
+            } catch (e: Throwable) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    @JvmStatic
+    fun getDeviceAssociation(
+        onError: OnErrorListener?,
+        listener: OnDeviceAssociationListener
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                sdk?.getDeviceAssociation(
+                    { error -> onError?.onError(error) },
+                    { association -> listener.onSuccess(association) }
+                )
+            } catch (e: Throwable) {
+                onError?.onError(e.toIDDigitalError())
+                listener.onSuccess(null)
+            }
+        }
+    }
+
+    @JvmStatic
+    fun createValidationSession(
+        context: Context,
+        type: ChallengeType,
+        onError: OnErrorListener?,
+        onCompleted: OnCompletedListener?
+    ) {
+        try {
+            sdk?.createValidationSession(
+                context,
+                type,
+                { error -> onError?.onError(error) },
+                { result -> onCompleted?.onCompleted(result) }
+            )
+        } catch (e: Throwable) {
+            onError?.onError(e.toIDDigitalError())
+        }
+    }
+
+//    @JvmStatic
+//    fun executeChallenge(
+//        challengeId: String,
+//        data: Record,
+//        onError: OnErrorListener?,
+//        onCompleted: OnCompletedListener?
+//    ) {
+//        CoroutineScope(Dispatchers.IO).launch {
+//            try {
+//                sdk?.executeChallenge(
+//                    challengeId,
+//                    data,
+//                    { error -> onError?.onError(error) },
+//                    { onCompleted?.onCompleted("Challenge executed successfully") }
+//                )
+//            } catch (e: Throwable) {
+//                onError?.onError(e.toIDDigitalError())
+//            }
+//        }
+//    }
+//
+//    @JvmStatic
+//    fun validateChallenge(
+//        challengeId: String,
+//        data: Record,
+//        onError: OnErrorListener?,
+//        listener: OnBooleanResultListener
+//    ) {
+//        CoroutineScope(Dispatchers.IO).launch {
+//            try {
+//                sdk?.validateChallenge(
+//                    challengeId,
+//                    data,
+//                    { error -> onError?.onError(error) },
+//                    { isValid -> listener.onResult(isValid) }
+//                )
+//            } catch (e: Throwable) {
+//                onError?.onError(e.toIDDigitalError())
+//                listener.onResult(false)
+//            }
+//        }
+//    }
+
+    @JvmStatic
+    fun sendToKeycloak(
+        tabId: String,
+        sessionCode: String,
+        clientId: String,
+        realm: String,
+        sdkToken: String,
+        onError: OnErrorListener?,
+        onSuccess: OnCompletedListener?
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                sdk?.sendToKeycloak(
+                    tabId,
+                    sessionCode,
+                    clientId,
+                    realm,
+                    sdkToken,
+                    { error -> onError?.onError(error) },
+                    { response -> onSuccess?.onCompleted(response) }
+                )
+            } catch (e: Throwable) {
+                onError?.onError(e.toIDDigitalError())
+            }
+        }
+    }
+}

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/DeviceAssociationDataStoreManager.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/DeviceAssociationDataStoreManager.kt
@@ -63,7 +63,8 @@ fun Context.getDeviceAssociation(): Flow<DeviceAssociation?> {
                     number = associationProto.document.number,
                     country = associationProto.document.country
                 ),
-                createdAt = associationProto.createdAt
+                createdAt = associationProto.createdAt,
+                idToken = associationProto.idToken
             )
         }
     }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/DeviceAssociationDataStoreManager.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/DeviceAssociationDataStoreManager.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.map
 import uy.com.abitab.iddigitalsdk.domain.models.DeviceAssociation
 import uy.com.abitab.iddigitalsdk.domain.models.Document
 
+/** Previous SDK versions persisted this when the API had no idToken; treat as absent when reading. */
+private const val LEGACY_PLACEHOLDER_ID_TOKEN = "TEMP_ID_TOKEN_PENDING_BACKEND"
 
 object DeviceAssociationSerializer : Serializer<DeviceAssociationProto> {
     override val defaultValue: DeviceAssociationProto = DeviceAssociationProto.getDefaultInstance()
@@ -29,9 +31,6 @@ object DeviceAssociationSerializer : Serializer<DeviceAssociationProto> {
         t.writeTo(output)
     }
 }
-
-// TODO: Remover cuando el backend envíe idToken correctamente
-private const val TEMP_ID_TOKEN = "TEMP_ID_TOKEN_PENDING_BACKEND"
 
 val Context.deviceAssociationStore: DataStore<DeviceAssociationProto> by dataStore(
     fileName = "device_association.pb",
@@ -50,7 +49,7 @@ suspend fun Context.saveDeviceAssociation(deviceAssociation: DeviceAssociation) 
             .setToken(deviceAssociation.token)
             .setDocument(documentProto)
             .setCreatedAt(deviceAssociation.createdAt)
-            .setIdToken(deviceAssociation.idToken ?: TEMP_ID_TOKEN)
+            .setIdToken(deviceAssociation.idToken.orEmpty())
             .build()
     }
 }
@@ -68,7 +67,9 @@ fun Context.getDeviceAssociation(): Flow<DeviceAssociation?> {
                     country = associationProto.document.country
                 ),
                 createdAt = associationProto.createdAt,
-                idToken = associationProto.idToken
+                idToken = associationProto.idToken.takeIf {
+                    it.isNotEmpty() && it != LEGACY_PLACEHOLDER_ID_TOKEN
+                }
             )
         }
     }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/DeviceAssociationDataStoreManager.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/DeviceAssociationDataStoreManager.kt
@@ -30,6 +30,9 @@ object DeviceAssociationSerializer : Serializer<DeviceAssociationProto> {
     }
 }
 
+// TODO: Remover cuando el backend envíe idToken correctamente
+private const val TEMP_ID_TOKEN = "TEMP_ID_TOKEN_PENDING_BACKEND"
+
 val Context.deviceAssociationStore: DataStore<DeviceAssociationProto> by dataStore(
     fileName = "device_association.pb",
     serializer = DeviceAssociationSerializer
@@ -47,6 +50,7 @@ suspend fun Context.saveDeviceAssociation(deviceAssociation: DeviceAssociation) 
             .setToken(deviceAssociation.token)
             .setDocument(documentProto)
             .setCreatedAt(deviceAssociation.createdAt)
+            .setIdToken(deviceAssociation.idToken ?: TEMP_ID_TOKEN)
             .build()
     }
 }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/network/KeycloakService.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/network/KeycloakService.kt
@@ -1,0 +1,93 @@
+package uy.com.abitab.iddigitalsdk.data.network
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import uy.com.abitab.iddigitalsdk.domain.models.IDDigitalSDKEnvironment
+import uy.com.abitab.iddigitalsdk.utils.BadResponseError
+import uy.com.abitab.iddigitalsdk.utils.NetworkUtils
+import uy.com.abitab.iddigitalsdk.utils.NoInternetConnection
+import uy.com.abitab.iddigitalsdk.utils.ServiceUnavailableError
+import uy.com.abitab.iddigitalsdk.utils.UnexpectedResponseError
+import uy.com.abitab.iddigitalsdk.utils.toIDDigitalError
+
+class KeycloakService(
+    private val httpClient: OkHttpClient,
+    private val context: Context
+) : BaseService() {
+
+    private fun getKeycloakBaseUrl(): String {
+        val environmentName: String? = getKoin().getProperty("environment")
+        val environment = try {
+            IDDigitalSDKEnvironment.valueOf(environmentName ?: IDDigitalSDKEnvironment.PRODUCTION.name)
+        } catch (e: IllegalArgumentException) {
+            IDDigitalSDKEnvironment.PRODUCTION
+        }
+        return when (environment) {
+            IDDigitalSDKEnvironment.STAGING -> "https://bqm-keycloak-dev.alabamasolutions.com"
+            IDDigitalSDKEnvironment.PRODUCTION -> "https://bqm-keycloak.alabamasolutions.com"
+        }
+    }
+
+    private fun buildKeycloakUrl(realm: String, path: String): String {
+        val baseUrl = getKeycloakBaseUrl()
+        return "$baseUrl/realms/$realm/$path"
+    }
+
+    suspend fun sendAuthenticationData(
+        tabId: String,
+        sessionCode: String,
+        clientId: String,
+        realm: String,
+        sdkToken: String,
+    ): String = withContext(Dispatchers.IO) {
+        if (!NetworkUtils.isInternetAvailable(context)) {
+            throw NoInternetConnection()
+        }
+
+        val formBody = FormBody.Builder()
+            .add("grant_type", "password")
+            .add("session_code", sessionCode)
+            .add("tab_id", tabId)
+            .add("client_id", clientId)
+            .add("sdk_token", sdkToken)
+            .build()
+
+        val url = buildKeycloakUrl(realm, "protocol/openid-connect/token")
+        val request = Request.Builder()
+            .post(formBody)
+            .url(url)
+            .addHeader("Content-Type", "application/x-www-form-urlencoded")
+            .build()
+
+        try {
+            httpClient.newCall(request).execute().use { response ->
+                val responseBody = response.body.string()
+                if (!response.isSuccessful) {
+                    throw when (response.code) {
+                        in 500..599 -> ServiceUnavailableError(
+                            response.code,
+                            responseBody
+                        )
+                        400, 404 -> BadResponseError(
+                            response.code,
+                            responseBody
+                        )
+                        else -> UnexpectedResponseError(
+                            response.code,
+                            responseBody
+                        )
+                    }
+                }
+
+                return@withContext responseBody
+            }
+        } catch (e: Throwable) {
+            throw e.toIDDigitalError("Error sending data to Keycloak")
+        }
+    }
+}
+

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/network/ValidationSessionService.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/data/network/ValidationSessionService.kt
@@ -13,6 +13,7 @@ import uy.com.abitab.iddigitalsdk.domain.models.CanAssociate
 import uy.com.abitab.iddigitalsdk.domain.models.ChallengeType
 import uy.com.abitab.iddigitalsdk.domain.models.DeviceAssociation
 import uy.com.abitab.iddigitalsdk.domain.models.Document
+import uy.com.abitab.iddigitalsdk.domain.models.Record
 import uy.com.abitab.iddigitalsdk.domain.models.ValidationSession
 import uy.com.abitab.iddigitalsdk.utils.ApiResponse
 import uy.com.abitab.iddigitalsdk.utils.BadResponseError
@@ -162,7 +163,6 @@ class ValidationSessionService(private val httpClient: OkHttpClient, private val
             }
         }
 
-
     suspend fun createValidationSession(challengeType: ChallengeType): ValidationSession =
         withContext(Dispatchers.IO) {
             if (!NetworkUtils.isInternetAvailable(context)) {
@@ -216,8 +216,11 @@ class ValidationSessionService(private val httpClient: OkHttpClient, private val
                 throw NoInternetConnection()
             }
 
+            val gson = Gson()
+            val json = gson.toJson(data)
+
             val request =
-                Request.Builder().post("$data".toRequestBody(JSON)) // Check if this works well
+                Request.Builder().post(json.toRequestBody(JSON))
                     .url(buildUrl("challenges/${challengeId}/execute/")).build()
 
             try {
@@ -324,6 +327,4 @@ class ValidationSessionService(private val httpClient: OkHttpClient, private val
         }
 
     }
-
-
 }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/di/KoinModule.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/di/KoinModule.kt
@@ -10,6 +10,7 @@ import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
 import uy.com.abitab.iddigitalsdk.data.PinDataStoreManager
 import uy.com.abitab.iddigitalsdk.data.network.ConfigService
+import uy.com.abitab.iddigitalsdk.data.network.KeycloakService
 import uy.com.abitab.iddigitalsdk.data.network.LivenessService
 import uy.com.abitab.iddigitalsdk.data.network.PinService
 import uy.com.abitab.iddigitalsdk.data.network.ValidationSessionService
@@ -23,9 +24,11 @@ import uy.com.abitab.iddigitalsdk.domain.usecases.CheckCanAssociateUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.CompleteDeviceAssociationUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.CreateDeviceAssociationUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.CreateValidationSessionUseCase
+//import uy.com.abitab.iddigitalsdk.domain.usecases.ExecuteChallengeUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.ExecuteLivenessChallengeUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.ExecutePinChallengeUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.RemoveAssociationUseCase
+//import uy.com.abitab.iddigitalsdk.domain.usecases.ValidateChallengeUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.ValidateLivenessChallengeUseCase
 import uy.com.abitab.iddigitalsdk.domain.usecases.ValidatePinChallengeUseCase
 import uy.com.abitab.iddigitalsdk.presentation.device_association.ui.viewmodels.DeviceAssociationViewModel
@@ -76,6 +79,7 @@ internal fun sdkModule() = module {
     single { PinService(get(), get()) }
     single { ValidationSessionService(get(), get()) }
     single { ConfigService(get()) }
+    single { KeycloakService(get(), get()) }
 
     // --- REPOSITORIES ---
     single<LivenessRepository> { LivenessRepositoryImpl(get()) }
@@ -97,6 +101,8 @@ internal fun sdkModule() = module {
     factory { RemoveAssociationUseCase(get(), Dispatchers.IO) }
     // validation session
     factory { CreateValidationSessionUseCase(get(), Dispatchers.IO) }
+//    factory { ExecuteChallengeUseCase(get(), Dispatchers.IO) }
+//    factory { ValidateChallengeUseCase(get(), Dispatchers.IO) }
 
 
     // --- VIEW MODELS ---

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/Challenge.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/Challenge.kt
@@ -9,29 +9,45 @@ data class Challenge(
     val expirationDate: String
 )
 
-sealed class ChallengeType : Serializable {
-    data object Liveness : ChallengeType() {
-        private fun readResolve(): Any = Liveness
-    }
+// TODO check if this is the best way to do it
+//sealed class ChallengeType : Serializable {
+//    data object Liveness : ChallengeType() {
+//        private fun readResolve(): Any = Liveness
+//    }
+//
+//    data object Pin : ChallengeType() {
+//        private fun readResolve(): Any = Pin
+//    }
+//
+//    companion object {
+//        fun fromString(typeString: String): ChallengeType? {
+//            return when (typeString.lowercase()) {
+//                "liveness" -> Liveness
+//                "pin" -> Pin
+//                else -> null
+//            }
+//        }
+//    }
+//
+//    override fun toString(): String {
+//        return when (this) {
+//            is Liveness -> "liveness"
+//            is Pin -> "pin"
+//        }
+//    }
+//}
 
-    data object Pin : ChallengeType() {
-        private fun readResolve(): Any = Pin
-    }
+enum class ChallengeType(val typeName: String) : Serializable {
+    Liveness("liveness"),
+    Pin("pin");
 
     companion object {
         fun fromString(typeString: String): ChallengeType? {
-            return when (typeString.lowercase()) {
-                "liveness" -> Liveness
-                "pin" -> Pin
-                else -> null
-            }
+            return entries.find { it.typeName.equals(typeString, ignoreCase = true) }
         }
     }
 
     override fun toString(): String {
-        return when (this) {
-            is Liveness -> "liveness"
-            is Pin -> "pin"
-        }
+        return typeName
     }
 }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/Record.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/Record.kt
@@ -1,0 +1,7 @@
+package uy.com.abitab.iddigitalsdk.domain.models
+
+typealias Record = Map<String, Any>
+
+
+
+

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/ValidationSession.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/ValidationSession.kt
@@ -10,6 +10,6 @@ data class ValidationSession(
     val payload: Map<String, Any>
 )
 
-data class DeviceAssociation(val token: String, val document: Document, val createdAt: String)
+data class DeviceAssociation(val token: String, val document: Document, val createdAt: String, val idToken: String)
 
 data class CanAssociate(val canAssociate: Boolean)

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/ValidationSession.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/models/ValidationSession.kt
@@ -10,6 +10,12 @@ data class ValidationSession(
     val payload: Map<String, Any>
 )
 
-data class DeviceAssociation(val token: String, val document: Document, val createdAt: String, val idToken: String)
+/** [idToken] is the OIDC ID Token (JWT) when the backend client has an active secret; null otherwise. */
+data class DeviceAssociation(
+    val token: String,
+    val document: Document,
+    val createdAt: String,
+    val idToken: String?,
+)
 
 data class CanAssociate(val canAssociate: Boolean)

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/repositories/ValidationSessionRepository.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/repositories/ValidationSessionRepository.kt
@@ -3,6 +3,7 @@ package uy.com.abitab.iddigitalsdk.domain.repositories
 import uy.com.abitab.iddigitalsdk.domain.models.DeviceAssociation
 import uy.com.abitab.iddigitalsdk.domain.models.ChallengeType
 import uy.com.abitab.iddigitalsdk.domain.models.Document
+import uy.com.abitab.iddigitalsdk.domain.models.Record
 import uy.com.abitab.iddigitalsdk.domain.models.ValidationSession
 
 interface ValidationSessionRepository {
@@ -11,4 +12,6 @@ interface ValidationSessionRepository {
     suspend fun completeDeviceAssociation(id: String): DeviceAssociation
     suspend fun createValidationSession(type: ChallengeType): ValidationSession
     suspend fun removeAssociation(): Unit
+//    suspend fun executeChallenge(challengeId: String, data: Record): Unit
+//    suspend fun validateChallenge(challengeId: String, data: Record): Boolean
 }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/repositories/ValidationSessionRepositoryImpl.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/repositories/ValidationSessionRepositoryImpl.kt
@@ -4,6 +4,7 @@ import uy.com.abitab.iddigitalsdk.domain.models.DeviceAssociation
 import uy.com.abitab.iddigitalsdk.data.network.ValidationSessionService
 import uy.com.abitab.iddigitalsdk.domain.models.ChallengeType
 import uy.com.abitab.iddigitalsdk.domain.models.Document
+import uy.com.abitab.iddigitalsdk.domain.models.Record
 import uy.com.abitab.iddigitalsdk.domain.models.ValidationSession
 
 class ValidationSessionRepositoryImpl(private val validationSessionService: ValidationSessionService) :
@@ -28,4 +29,12 @@ class ValidationSessionRepositoryImpl(private val validationSessionService: Vali
     override suspend fun removeAssociation(): Unit {
         return validationSessionService.removeAssociation()
     }
+
+//    override suspend fun executeChallenge(challengeId: String, data: Record): Unit {
+//        return validationSessionService.executeChallenge(challengeId, data)
+//    }
+//
+//    override suspend fun validateChallenge(challengeId: String, data: Record): Boolean {
+//        return validationSessionService.validateChallenge(challengeId, data)
+//    }
 }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/usecases/ExecuteChallengeUseCase.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/usecases/ExecuteChallengeUseCase.kt
@@ -1,0 +1,25 @@
+package uy.com.abitab.iddigitalsdk.domain.usecases
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import uy.com.abitab.iddigitalsdk.domain.models.Record
+import uy.com.abitab.iddigitalsdk.domain.repositories.ValidationSessionRepository
+
+class ExecuteChallengeUseCase(
+    private val validationSessionRepository: ValidationSessionRepository,
+    private val dispatcher: CoroutineDispatcher,
+) {
+//    suspend operator fun invoke(challengeId: String, data: Record): Unit =
+//        withContext(dispatcher) {
+//            return@withContext validationSessionRepository.executeChallenge(challengeId, data)
+//        }
+}
+
+
+
+
+
+
+
+
+

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/usecases/ValidateChallengeUseCase.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/domain/usecases/ValidateChallengeUseCase.kt
@@ -1,0 +1,19 @@
+package uy.com.abitab.iddigitalsdk.domain.usecases
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import uy.com.abitab.iddigitalsdk.domain.models.Record
+import uy.com.abitab.iddigitalsdk.domain.repositories.ValidationSessionRepository
+
+class ValidateChallengeUseCase(
+    private val validationSessionRepository: ValidationSessionRepository,
+    private val dispatcher: CoroutineDispatcher,
+) {
+//    suspend operator fun invoke(challengeId: String, data: Record): Boolean =
+//        withContext(dispatcher) {
+//            return@withContext validationSessionRepository.validateChallenge(challengeId, data)
+//        }
+}
+
+
+

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/screens/DeviceAssociation.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/screens/DeviceAssociation.kt
@@ -61,7 +61,8 @@ fun DeviceAssociation(document: Document, context: Context, onClose: () -> Unit)
             }
 
             is DeviceAssociationUiState.Success -> {
-                CallbackHandler.onCompleted("Device association successful")
+                val idToken = (uiState as DeviceAssociationUiState.Success).idToken
+                CallbackHandler.onCompleted(idToken)
                 (context as? Activity)?.finish()
             }
 

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/viewmodels/DeviceAssociationViewModel.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/viewmodels/DeviceAssociationViewModel.kt
@@ -91,7 +91,7 @@ class DeviceAssociationViewModel(
 
         context.saveDeviceAssociation(deviceAssociation)
         viewModelScope.launch {
-            _uiState.emit(DeviceAssociationUiState.Success)
+            _uiState.emit(DeviceAssociationUiState.Success(deviceAssociation.idToken))
         }
     }
 
@@ -200,6 +200,6 @@ sealed class DeviceAssociationUiState {
     data class LaunchChallenge(val challenge: Challenge, val isRetry: Boolean = false) :
         DeviceAssociationUiState()
 
-    object Success : DeviceAssociationUiState()
+    data class Success(val idToken: String) : DeviceAssociationUiState()
     data class Error(val error: IDDigitalError) : DeviceAssociationUiState()
 }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/viewmodels/DeviceAssociationViewModel.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/viewmodels/DeviceAssociationViewModel.kt
@@ -91,8 +91,8 @@ class DeviceAssociationViewModel(
 
         context.saveDeviceAssociation(deviceAssociation)
         viewModelScope.launch {
-            // TODO: Remover cuando el backend envíe idToken correctamente
-            val idToken = deviceAssociation.idToken ?: "TEMP_ID_TOKEN_PENDING_BACKEND"
+            // Empty string when backend omits idToken (e.g. client without active secret).
+            val idToken = deviceAssociation.idToken.orEmpty()
             _uiState.emit(DeviceAssociationUiState.Success(idToken))
         }
     }

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/viewmodels/DeviceAssociationViewModel.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/presentation/device_association/ui/viewmodels/DeviceAssociationViewModel.kt
@@ -91,7 +91,9 @@ class DeviceAssociationViewModel(
 
         context.saveDeviceAssociation(deviceAssociation)
         viewModelScope.launch {
-            _uiState.emit(DeviceAssociationUiState.Success(deviceAssociation.idToken))
+            // TODO: Remover cuando el backend envíe idToken correctamente
+            val idToken = deviceAssociation.idToken ?: "TEMP_ID_TOKEN_PENDING_BACKEND"
+            _uiState.emit(DeviceAssociationUiState.Success(idToken))
         }
     }
 

--- a/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/utils/Types.kt
+++ b/IDDigitalSDK/src/main/java/uy/com/abitab/iddigitalsdk/utils/Types.kt
@@ -1,7 +1,5 @@
 package uy.com.abitab.iddigitalsdk.utils
 
-import uy.com.abitab.iddigitalsdk.domain.models.Document
-
 data class ApiResponse<T>(
     val data: T,
 )

--- a/IDDigitalSDK/src/main/proto/device_association.proto
+++ b/IDDigitalSDK/src/main/proto/device_association.proto
@@ -13,4 +13,5 @@ message DeviceAssociationProto {
   string token = 1;
   DocumentProto document = 2;
   string created_at = 3;
+  string id_token = 4;
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,17 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
 }
+
+val localProperties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localProperties.load(FileInputStream(localPropertiesFile))
+}
+val apiKey = localProperties.getProperty("API_KEY") ?: ""
 
 android {
     namespace = "com.example.iddigital"
@@ -15,7 +25,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "API_KEY", "\"j7_hiid70M0Sz3hFOA_npzbKfRVGPXLBozsIzzE_h5U\"")
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {

--- a/app/src/main/java/com/example/iddigital/Examples.kt
+++ b/app/src/main/java/com/example/iddigital/Examples.kt
@@ -1,3 +1,4 @@
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -105,7 +106,10 @@ fun Examples(sdkInstance: IDDigitalSDK, onError: (IDDigitalError) -> Unit) {
 
                 AssociateDevice(sdkInstance,
                     documentNumber = documentNumber,
-                    onCompleted = { documentNumber = "" })
+                    onCompleted = { idToken ->
+                        Log.d("MainActivity", "ID Token: $idToken")
+                        documentNumber = ""
+                    })
                 CheckAssociation(sdkInstance)
 
                 RemoveAssociation(sdkInstance)
@@ -137,7 +141,7 @@ fun Examples(sdkInstance: IDDigitalSDK, onError: (IDDigitalError) -> Unit) {
 }
 
 @Composable
-fun AssociateDevice(sdkInstance: IDDigitalSDK, documentNumber: String, onCompleted: () -> Unit) {
+fun AssociateDevice(sdkInstance: IDDigitalSDK, documentNumber: String, onCompleted: (idToken: String) -> Unit) {
     val context = LocalContext.current
     val coroutineScope = remember { CoroutineScope(Dispatchers.Main) }
 
@@ -147,11 +151,11 @@ fun AssociateDevice(sdkInstance: IDDigitalSDK, documentNumber: String, onComplet
             try {
                 sdkInstance.associate(context = context, document = Document(
                     number = documentNumber
-                ), onCompleted = {
+                ), onCompleted = { idToken ->
                     Toast.makeText(
                         context, "Dispositivo asociado con éxito", Toast.LENGTH_SHORT
                     ).show()
-                    onCompleted()
+                    onCompleted(idToken)
                 }, onError = {
                     Toast.makeText(
                         context, "Error al asociar dispositivo: $it", Toast.LENGTH_SHORT

--- a/app/src/main/java/com/example/iddigital/MainActivity.kt
+++ b/app/src/main/java/com/example/iddigital/MainActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -14,8 +13,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import uy.com.abitab.iddigitalsdk.IDDigitalSDK
 import uy.com.abitab.iddigitalsdk.domain.models.IDDigitalSDKEnvironment

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,0 +1,3 @@
+# Copy to local.properties (not committed). Android Studio usually adds sdk.dir.
+# Required for the sample app :app module BuildConfig.API_KEY.
+API_KEY=


### PR DESCRIPTION


## Summary
This branch completes the device-association flow so the client app receives a real **OIDC ID token (JWT)** from the backend (when the SDK client has an active secret), persists it correctly, and sends it to **Keycloak** as `sdk_token`—without relying on placeholder strings. 

The native POC apps are now aligned on using the **ID token** versus the opaque association token and have been updated to avoid logging sensitive secrets.

---

## Changes

* **Data Models:** `DeviceAssociation.idToken` is now `String?`, matching the API response structure when the token is null.
* **Persistence:** Updated DataStore/Proto to persist the real JWT or an empty string. When reading, the SDK now treats empty values as absent and ignores the legacy `TEMP_ID_TOKEN_PENDING_BACKEND` flag if present.
* **Callbacks:** Association success still exposes a `String` to the callback via `idToken.orEmpty()`.
* **Keycloak Integration:** Updated `sendToKeycloak` documentation to specify that `sdkToken` must be the OIDC JWT obtained from `DeviceAssociation.idToken`.
* **General:** Includes earlier work on challenge handling, Maven publication (1.0.0), and repository metadata cleanup.

---

## Impact
- **Security:** Removed placeholder strings and prevented the logging of secrets in POC implementations.
- **Consistency:** Standardized the handoff between the SDK and Keycloak across both mobile platforms.
- **Backward Compatibility:** Handled legacy token flags to ensure a smooth transition during local data migrations.

